### PR TITLE
Check if the returned intent is for purchasing

### DIFF
--- a/android/src/main/java/com/squaretwo/applovin/eventtracker/RNApplovinEventTrackerModule.java
+++ b/android/src/main/java/com/squaretwo/applovin/eventtracker/RNApplovinEventTrackerModule.java
@@ -48,12 +48,15 @@ public class RNApplovinEventTrackerModule extends ReactContextBaseJavaModule imp
     if (this.lastPurchaseIntent != null ) {
       eventService.trackInAppPurchase(this.lastPurchaseIntent, parameters);
       Log.d(TAG, "inAppPurchaseEvent amountOfMoneySpent:" + amountOfMoneySpent + ", currency:" + currency + ", intent:" + this.lastPurchaseIntent.toString());
+      this.lastPurchaseIntent = null;
     }
   }
 
   @Override
   public void onActivityResult(final Activity activity, final int requestCode, final int resultCode, final Intent intent) {
-    this.lastPurchaseIntent = intent;
+    if (intent.getStringExtra("INAPP_PURCHASE_DATA") != null) {
+       this.lastPurchaseIntent = intent;
+    }
   }
 
   @Override


### PR DESCRIPTION
@rayjo-squaretwo 

It's not recommending adding multiple observers to the payment queue.
Since InAppUtils library adds an observer, we better not adding an observer again.
https://developer.apple.com/documentation/storekit/skpaymentqueue/1506042-addtransactionobserver
`It is recommended that you use a single observer to process and finish the transaction.`